### PR TITLE
Feature: Send existing payees to Gemini for classification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 
 .vscode-test
+.vscode
 
 # yarn v2
 
@@ -173,3 +174,6 @@ dist
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# tmp
+tmp

--- a/services/budget.ts
+++ b/services/budget.ts
@@ -31,6 +31,20 @@ export const getAllEnvelopes = async () => {
   return envelopes;
 };
 
+export const getAllPayees = async () => {
+  const budget = await api.budgets.getBudgetById(budgetId);
+
+  const payees = budget.data.budget.payees
+    ?.filter((p) => p.name && !p.deleted)
+    .map((p) => p.name);
+
+  if (!payees) {
+    throw new Error("No payees found");
+  }
+
+  return payees;
+};
+
 export const createTransaction = async (
   accountName: string,
   merchant: string,

--- a/services/gen-ai.ts
+++ b/services/gen-ai.ts
@@ -75,7 +75,8 @@ const getGeneratingConfig = (
 export const parseReceipt = async (
   image: Buffer,
   mimeType: string,
-  availableEnvelopes: string[]
+  availableEnvelopes: string[],
+  existingPayees: string[] | null = null
 ): Promise<Receipt | null> => {
   const chatSession = model.startChat({
     generationConfig: getGeneratingConfig(availableEnvelopes),
@@ -84,7 +85,13 @@ export const parseReceipt = async (
 
   const result = await chatSession.sendMessage([
     {
-      text: "Process this slip",
+      text: `Process this slip. Make sure you ONLY use a category in the list of available enum values. ${
+        existingPayees
+          ? `\n\nConsider the following existing merchants and pick the most appropriate one. If none are appropriate, use the merchant name from the receipt:\n${existingPayees
+              .map((p) => `- ${p}`)
+              .join("\n")}`
+          : ""
+      }`,
     },
     {
       inlineData: {

--- a/services/receipt.ts
+++ b/services/receipt.ts
@@ -2,9 +2,11 @@ import type { Receipt } from "./shared-types";
 import {
   createTransaction,
   getAllEnvelopes as getAllCategories,
+  getAllPayees,
 } from "./budget";
 import { parseReceipt } from "./gen-ai";
 import { getStorageService } from "./storage";
+import env from "../utils/env-vars";
 
 const storageService = getStorageService();
 
@@ -19,8 +21,17 @@ export const processAndUploadReceipt = async (
 
   let receipt: Receipt | null = null;
 
+  let ynabPayees = env.YNAB_INCLUDE_PAYEES_IN_PROMPT
+    ? await getAllPayees()
+    : null;
+
   try {
-    receipt = await parseReceipt(fileBuffer, file.type, ynabCategories);
+    receipt = await parseReceipt(
+      fileBuffer,
+      file.type,
+      ynabCategories,
+      ynabPayees
+    );
 
     if (!receipt) {
       throw new Error("Receipt was supposedly parsed but null was returned.");

--- a/utils/env-vars.ts
+++ b/utils/env-vars.ts
@@ -9,6 +9,10 @@ const envScheme = z.object({
     .string()
     .optional()
     .transform((str) => str?.split(",") || []),
+  YNAB_INCLUDE_PAYEES_IN_PROMPT: z.preprocess(
+    (val) => `${val}`.toLowerCase() !== "false",
+    z.boolean()
+  ),
   APP_PORT: z
     .string()
     .optional()


### PR DESCRIPTION
This ticket implements a suggestion raised in #10.

You can now choose to include a list of all the payees in your YNAB budget by setting the following environment:
`YNAB_INCLUDE_PAYEES_IN_PROMPT=true`